### PR TITLE
Add debug logging + fix critical callback bugs

### DIFF
--- a/src/clipboard_parser.py
+++ b/src/clipboard_parser.py
@@ -2,7 +2,10 @@ import re
 from collections import namedtuple
 from typing import List, Optional
 import pyperclip
+import logging
 from os import linesep
+
+logger = logging.getLogger("scribe_reformatter.parser")
 
 SectionResponse = namedtuple("SectionResponse", ["output", "newlines_handled"])
 
@@ -11,12 +14,6 @@ class ConsultationParseError(Exception):
     """Raised when the clipboard content cannot be parsed as a valid consultation."""
 
     def __init__(self, message: str, clipboard_preview: Optional[str] = None):
-        """Initialize the error with a message and optional clipboard preview.
-
-        Args:
-            message: Description of what went wrong
-            clipboard_preview: First 100 chars of clipboard content for debugging
-        """
         self.message = message
         self.clipboard_preview = clipboard_preview[:100] if clipboard_preview else None
         super().__init__(self.message)
@@ -25,6 +22,7 @@ class ConsultationParseError(Exception):
         if self.clipboard_preview:
             return f"{self.message} | Clipboard preview: '{self.clipboard_preview}...'"
         return self.message
+
 
 # Configuration for heading pattern matching
 HEADING_PATTERNS = {
@@ -51,12 +49,15 @@ class BlockItem:
             for pattern in patterns:
                 if re.match(pattern, self.heading):
                     return section_type
+        logger.debug("Heading '%s' did not match any known section pattern", self.heading)
         return None
 
     def parse(self):
         output = ""
 
         section_type = self._match_heading_type()
+        logger.debug("Parsing block: heading='%s' matched_section=%s bullets=%d",
+                      self.heading, section_type, len(self.bullets))
 
         if section_type == 'history':
             result = self.parse_history()
@@ -75,6 +76,8 @@ class BlockItem:
         if not result.newlines_handled:
             output += "\n\n"
 
+        logger.debug("Block parse result: %d chars, newlines_handled=%s",
+                      len(output), result.newlines_handled)
         return output
 
     def parse_history(self):
@@ -87,10 +90,12 @@ class BlockItem:
             output = self.comma_separated_prose
         else:
             output = "Hx of " + self.comma_separated_prose
+        logger.debug("PMH output: %s", output[:200])
         return SectionResponse(output, False)
 
     def parse_exam(self):
         if self.comma_separated_prose == "N/A":
+            logger.debug("Exam is N/A — skipping")
             return SectionResponse("", True)
 
         self.heading = "Examination:"
@@ -99,6 +104,7 @@ class BlockItem:
 
     def parse_imp(self):
         if self.comma_separated_prose == "Not explicitly mentioned":
+            logger.debug("Impression not explicitly mentioned — skipping")
             return SectionResponse("", True)
 
         self.heading = "Impression:"
@@ -112,7 +118,7 @@ class BlockItem:
         return None
 
     def parse_unhandled(self):
-        # return SectionResponse(self.heading + "\n" + "\n".join(self.bullets), False)
+        logger.debug("Unhandled heading '%s' — treating as prose block", self.heading)
         return SectionResponse(self.heading + " " + self.prose + "\n", True)
 
 
@@ -122,7 +128,8 @@ def block_parser(block: str) -> BlockItem:
     block = block.lstrip().rstrip()
 
     if block == "":
-        return None  # Guard for empty block entirely
+        logger.debug("Skipping empty block")
+        return None
 
     contents = block.splitlines()
 
@@ -133,10 +140,13 @@ def block_parser(block: str) -> BlockItem:
     bullets = [b for b in bullets if b.strip() and not all(c in '-_=' for c in b.strip())]
 
     if not bullets:
-        return None  # Guard for a block with a heading but no contents
+        logger.debug("Skipping block with heading '%s' but no valid bullets", heading)
+        return None
 
     prose = parse_bullets_to_prose(contents)
     comma_separated_prose = parse_bullets_to_comma_separated_prose(contents)
+
+    logger.debug("block_parser: heading='%s' bullets=%d", heading, len(bullets))
 
     item = BlockItem(
         heading=heading,
@@ -184,10 +194,14 @@ def get_items(consultation: str):
     # Need to split on two subsequent linebreaks, different on windows vs linux
     if "\r\n" in consultation:
         sections = consultation.split("\r\n\r\n")
+        logger.debug("Splitting on \\r\\n\\r\\n (Windows line endings) — %d blocks", len(sections))
     else:
         sections = consultation.split("\n\n")
+        logger.debug("Splitting on \\n\\n (Unix line endings) — %d blocks", len(sections))
 
     items = [block_parser(s) for s in sections]
+    non_none = [i for i in items if i is not None]
+    logger.debug("get_items: %d blocks total, %d non-None items", len(items), len(non_none))
     return items
 
 
@@ -206,34 +220,21 @@ def _get_section_category(heading):
         "Impression:": "imp",
         "Plan:": "plan",
     }
-    return section_map.get(heading)
+    cat = section_map.get(heading)
+    if cat is None and heading:
+        logger.debug("Heading '%s' not in _get_section_category map", heading)
+    return cat
 
 
 def _format_section_output(output, heading, current_section):
-    """Format output based on section context.
-
-    Args:
-        output: The parsed output string
-        heading: The heading of the current item
-        current_section: The current section being processed
-
-    Returns:
-        str: Formatted output string
-    """
-    # Add newline before non-History subsections in the history section
+    """Format output based on section context."""
     if current_section == "history" and heading != 'History:':
         output = "\r\n" + output
     return output
 
 
 def _append_to_section(result, section_key, output):
-    """Append output to a section, handling None values.
-
-    Args:
-        result: The result dictionary
-        section_key: The section key to append to
-        output: The output string to append
-    """
+    """Append output to a section, handling None values."""
     if result[section_key]:
         result[section_key] += output
     else:
@@ -255,6 +256,9 @@ def validate_consultation_content(content: str) -> None:
     # Check for required consultation markers
     has_history = any(marker in content for marker in ["History:", "History\n", "History\r\n"])
     has_plan = any(marker in content for marker in ["Plan:", "Plan\n", "Plan\r\n"])
+
+    logger.debug("Validation: has_history=%s has_plan=%s content_length=%d",
+                  has_history, has_plan, len(content))
 
     if not has_history:
         raise ConsultationParseError(
@@ -292,16 +296,28 @@ def get_split_sections(consultation: str) -> dict:
     # Validate content before parsing
     validate_consultation_content(consultation)
 
-    main_history = consultation.partition('\r\nPatient Summary')[0]  # Dump patient summary and after
+    # Try Windows line ending first, fall back to Unix
+    if '\r\nPatient Summary' in consultation:
+        main_history = consultation.partition('\r\nPatient Summary')[0]
+        logger.debug("Stripped Patient Summary (found \\r\\n separator)")
+    elif '\nPatient Summary' in consultation:
+        main_history = consultation.partition('\nPatient Summary')[0]
+        logger.debug("Stripped Patient Summary (found \\n separator)")
+    else:
+        main_history = consultation
+        logger.debug("No Patient Summary found in content")
+
     items = get_items(main_history)
 
     result = dict.fromkeys(["history", "exam", "imp", "plan"])
     current_section = "history"
 
-    for item in items:
+    for idx, item in enumerate(items):
         if item is None:
             continue
-        
+
+        logger.debug("Processing item %d: heading='%s'", idx, item.heading)
+
         output = item.parse()
         output = linesep.join([s for s in output.splitlines() if s])
 
@@ -309,10 +325,12 @@ def get_split_sections(consultation: str) -> dict:
         section_category = _get_section_category(item.heading)
         if section_category:
             current_section = section_category
+            logger.debug("Current section changed to '%s' (from heading '%s')",
+                          section_category, item.heading)
 
-        # Special case: Investigations always go in history (check for variations in heading format)
+        # Special case: Investigations always go in history
         if "Investigations" in item.heading:
-            # Ensure it's on its own line with proper spacing
+            logger.debug("Investigations block — appending to history section")
             if result["history"]:
                 _append_to_section(result, "history", "\r\n\r\n" + output)
             else:
@@ -321,6 +339,8 @@ def get_split_sections(consultation: str) -> dict:
             output = _format_section_output(output, item.heading, current_section)
             _append_to_section(result, current_section, output)
 
+    logger.debug("Final sections: %s",
+                  {k: f"{len(v)} chars" if v else "None" for k, v in result.items()})
     return result
 
 

--- a/src/history_clipboard_manager.py
+++ b/src/history_clipboard_manager.py
@@ -8,10 +8,69 @@ from datetime import datetime, timedelta
 import pyautogui as ag
 import pystray
 from sys import exit
+import logging
+import sys
+import traceback
 
 from PIL import Image, ImageDraw
 from pathlib import Path
 
+
+# ---------------------------------------------------------------------------
+# Logging setup
+# ---------------------------------------------------------------------------
+
+LOG_FILE = Path.cwd() / "scribe_reformatter_debug.log"
+
+# Module-level logger — children can do: logging.getLogger(__name__)
+logger = logging.getLogger("scribe_reformatter")
+
+
+def setup_logging(debug_mode: bool = False):
+    """Configure logging with console + file handlers.
+
+    The **file handler** always captures DEBUG-level output so the log file
+    is useful even when the user hasn't explicitly enabled debug mode.
+    The **console handler** respects *debug_mode* to control verbosity.
+    """
+    root = logging.getLogger("scribe_reformatter")
+    root.setLevel(logging.DEBUG)
+
+    fmt = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)-7s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # ---- File handler (always DEBUG) ----
+    fh = logging.FileHandler(str(LOG_FILE), encoding="utf-8", mode="a")
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(fmt)
+    root.addHandler(fh)
+
+    # ---- Console handler ----
+    console_level = logging.DEBUG if debug_mode else logging.INFO
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(console_level)
+    ch.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+    root.addHandler(ch)
+
+    logger.info("Logging initialised — log file: %s", LOG_FILE)
+    logger.info("Debug mode (console): %s | File always captures DEBUG", debug_mode)
+
+
+def set_console_debug(enabled: bool):
+    """Toggle the console handler between DEBUG and INFO without touching
+    the file handler (which is always DEBUG)."""
+    root = logging.getLogger("scribe_reformatter")
+    for h in root.handlers:
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+            h.setLevel(logging.DEBUG if enabled else logging.INFO)
+    logger.info("Console logging set to %s", "DEBUG" if enabled else "INFO")
+
+
+# ---------------------------------------------------------------------------
+# Icons
+# ---------------------------------------------------------------------------
 
 class IconManager:
     """Manages loading and compositing system tray icons."""
@@ -30,15 +89,14 @@ class IconManager:
     def _load_icons(self):
         """Load all icon files from disk."""
         try:
-            # Load base medical cross icon
             main_icon_path = self.icons_dir / "main.png"
             if main_icon_path.exists():
                 self.base_icon = Image.open(main_icon_path)
+                logger.debug("Loaded base icon from %s", main_icon_path)
             else:
-                print(f"Warning: Base icon not found at {main_icon_path}")
+                logger.warning("Base icon not found at %s — using fallback", main_icon_path)
                 self.base_icon = self._create_fallback_icon()
 
-            # Load badge overlays
             badge_files = {
                 'ready': 'badge_ready.png',
                 'plan': 'badge_plan.png',
@@ -49,32 +107,30 @@ class IconManager:
                 badge_path = self.icons_dir / filename
                 if badge_path.exists():
                     self.badges[state] = Image.open(badge_path).convert("RGBA")
+                    logger.debug("Loaded %s badge from %s", state, badge_path)
                 else:
-                    print(f"Warning: Badge icon not found at {badge_path}")
+                    logger.warning("Badge not found at %s — using fallback", badge_path)
                     self.badges[state] = self._create_fallback_badge(state)
 
         except Exception as e:
-            print(f"Error loading icons: {e}")
+            logger.error("Error loading icons: %s", e, exc_info=True)
             self.base_icon = self._create_fallback_icon()
 
     def _create_fallback_icon(self):
         """Create a simple fallback icon if files are missing."""
         image = Image.new("RGBA", (64, 64), (0, 100, 200, 255))
         dc = ImageDraw.Draw(image)
-        # Draw a simple medical cross
         center = 32
-        # Horizontal bar
         dc.rectangle([center - 10, center - 3, center + 10, center + 3], fill=(255, 255, 255, 255))
-        # Vertical bar
         dc.rectangle([center - 3, center - 10, center + 3, center + 10], fill=(255, 255, 255, 255))
         return image
 
     def _create_fallback_badge(self, state):
         """Create fallback badge if files are missing."""
         colors = {
-            'ready': (0, 200, 0, 230),    # Green
-            'plan': (255, 165, 0, 230),    # Orange
-            'error': (220, 0, 0, 230)      # Red
+            'ready': (0, 200, 0, 230),
+            'plan': (255, 165, 0, 230),
+            'error': (220, 0, 0, 230)
         }
         badge = Image.new("RGBA", (32, 32), (0, 0, 0, 0))
         dc = ImageDraw.Draw(badge)
@@ -82,22 +138,12 @@ class IconManager:
         return badge
 
     def get_icon_for_state(self, state):
-        """Get the appropriate icon for the given application state.
-
-        Args:
-            state: State enum value
-
-        Returns:
-            PIL.Image: Composited icon for the state
-        """
-        # Start with base icon
+        """Get the appropriate icon for the given application state."""
         if self.base_icon is None:
             return self._create_fallback_icon()
 
-        # Ensure base icon is RGBA for compositing
         icon = self.base_icon.convert("RGBA")
 
-        # Add appropriate badge based on state
         if state == State.COPIED:
             badge = self.badges.get('ready')
         elif state == State.PLAN_PASTE:
@@ -105,16 +151,17 @@ class IconManager:
         elif state == State.PARSE_ERROR:
             badge = self.badges.get('error')
         else:
-            # PLAN_PASTED state - no badge
             return icon
 
-        # Composite badge onto icon if available
         if badge:
-            # Position badge in bottom-right corner
             icon.paste(badge, (icon.width - badge.width, icon.height - badge.height), badge)
 
         return icon
 
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
 
 class State(Enum):
     COPIED = 1
@@ -145,10 +192,14 @@ class ApplicationState:
     def reset_consultation(self):
         """Reset the consultation data."""
         self.consultation = {}
+        logger.debug("Consultation data reset")
 
     def is_plan_paste_expired(self):
         """Check if the plan paste time window has expired."""
-        return datetime.now() - self.first_paste > self.PLAN_PASTE_TIME
+        expired = datetime.now() - self.first_paste > self.PLAN_PASTE_TIME
+        logger.debug("Plan paste expired check: %s (elapsed=%s, timeout=%s)",
+                      expired, datetime.now() - self.first_paste, self.PLAN_PASTE_TIME)
+        return expired
 
     def is_parse_error_expired(self):
         """Check if parse error timeout has expired."""
@@ -162,121 +213,137 @@ class ApplicationState:
                 self.is_parse_error_expired())
 
 
-def handle_plan_pasted_state(app_state):
-    """Handle the initial history collection state.
+# ---------------------------------------------------------------------------
+# State handlers
+# ---------------------------------------------------------------------------
 
-    Args:
-        app_state: ApplicationState instance
+def handle_plan_pasted_state(app_state):
+    """Handle the initial history collection — copy from Heidi, parse, show GUI.
+
+    The entire body is wrapped in try/except so that pyautogui or pyperclip
+    failures (e.g. FailSafeException, empty clipboard) cannot kill the mouse
+    callback permanently.
     """
-    print("Section 1: History collection")
+    logger.info("State handler: PLAN_PASTED → collecting consultation from clipboard")
     app_state.reset_consultation()
 
-    ag.click()
-    ag.hotkey("ctrl", "a")
-    ag.hotkey("ctrl", "c")
+    try:
+        logger.debug("Performing click + Ctrl+A + Ctrl+C to capture consultation")
+        ag.click()
+        ag.hotkey("ctrl", "a")
+        ag.hotkey("ctrl", "c")
+        time.sleep(0.1)  # brief settle
 
-    clip = pyperclip.paste()
+        clip = pyperclip.paste()
+        logger.debug("Clipboard captured — length=%d chars", len(clip) if clip else 0)
+        logger.debug("Clipboard preview:\n%s", _safe_preview(clip))
+
+    except Exception as e:
+        logger.error("Failed to capture clipboard: %s: %s", type(e).__name__, e,
+                      exc_info=True)
+        app_state.state = State.PARSE_ERROR
+        app_state.parse_error_time = datetime.now()
+        return
 
     try:
+        logger.debug("Parsing consultation sections...")
         sections = get_split_sections(clip)
+
+        logger.debug("Parsed sections: %s",
+                      {k: f"{len(v)} chars" if v else "empty" for k, v in sections.items()})
 
         if sections['history'] and app_state.record_consent:
             sections['history'] += '\r\n(verbal consent given for AI transcription)'
+            logger.debug("Appended consent note to history")
 
         if app_state.bypass_gui:
-            # Skip GUI - use sections directly after removing headings
+            logger.info("Bypass GUI enabled — using sections directly")
             g = Gui(sections)
             g.remove_headings()
             app_state.consultation = g.state
         else:
-            # Show GUI for editing
+            logger.info("Showing GUI editor")
             g = Gui(sections)
             g.remove_headings()
             app_state.consultation = g.show_gui()
+            logger.debug("GUI returned consultation keys: %s", list(app_state.consultation.keys()))
 
+        logger.info("Consultation parsed successfully → state COPIED")
         app_state.state = State.COPIED
 
     except ConsultationParseError as e:
-        # Content didn't match expected consultation format
-        print(f"Consultation parsing failed: {e}")
-        print("Please ensure you've copied a valid consultation from Heidi")
+        logger.warning("ConsultationParseError: %s", e)
+        logger.debug("Full clipboard that failed to parse:\n%s", _safe_preview(clip, max_chars=2000))
         app_state.state = State.PARSE_ERROR
         app_state.parse_error_time = datetime.now()
 
     except (KeyError, ValueError, AttributeError) as e:
-        # Data structure or value errors during parsing
-        print(f"Error processing consultation data: {type(e).__name__}: {e}")
-        print("The consultation format may have changed")
+        logger.error("Data structure error during parsing: %s: %s", type(e).__name__, e,
+                      exc_info=True)
         app_state.state = State.PARSE_ERROR
         app_state.parse_error_time = datetime.now()
 
     except Exception as e:
-        # Catch-all for unexpected errors (e.g., GUI errors)
-        print(f"Unexpected error: {type(e).__name__}: {e}")
-        print("Please check the consultation format and try again")
+        logger.error("Unexpected error during parsing/GUI: %s: %s", type(e).__name__, e,
+                      exc_info=True)
         app_state.state = State.PARSE_ERROR
         app_state.parse_error_time = datetime.now()
 
 
 def handle_copied_state(app_state):
-    """Handle pasting sections after consultation is copied.
-
-    Args:
-        app_state: ApplicationState instance
-    """
-    print("Section 2: Pasting")
+    """Handle pasting sections into SystmOne."""
+    logger.info("State handler: COPIED → pasting sections into SystmOne")
     for s in ["history", "exam", "imp", "plan"]:
         if s in app_state.consultation:
+            logger.debug("Pasting section '%s' (%d chars)", s, len(app_state.consultation[s]))
             pyperclip.copy(app_state.consultation[s])
             ag.hotkey("ctrl", "v")
+        else:
+            logger.debug("Section '%s' is empty — skipping, pressing tab", s)
         ag.press("tab")
         time.sleep(0.3)
     app_state.first_paste = datetime.now()
-
-    # Reset parse error state on successful copy
-    if app_state.state == State.PARSE_ERROR:
-        app_state.parse_error_time = None
-
     app_state.state = State.PLAN_PASTE
+    logger.info("All sections pasted → state PLAN_PASTE (window: %ss)",
+                app_state.PLAN_PASTE_TIME.total_seconds())
 
 
 def handle_plan_paste_state(app_state):
-    """Handle pasting the plan section.
-
-    Args:
-        app_state: ApplicationState instance
-    """
-    print("Section 3: Pasting Plan")
+    """Handle pasting the plan section separately."""
+    logger.info("State handler: PLAN_PASTE → pasting plan into Plan field")
     ag.click()
     ag.hotkey("ctrl", "v")
     app_state.state = State.PLAN_PASTED
+    logger.info("Plan pasted → state PLAN_PASTED")
 
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
 
 def middle_mouse(app_state):
-    """Handle middle mouse button clicks based on current application state.
+    """Handle middle mouse button clicks based on current application state."""
+    logger.debug("Middle click received — current state: %s", app_state.state.name)
 
-    Args:
-        app_state: ApplicationState instance containing all application state
-    """
     # Auto-reset from parse error after timeout
     if app_state.should_reset_from_parse_error():
-        print("Parse error timeout expired, resetting to normal state")
+        logger.info("Parse error timeout expired — auto-resetting to PLAN_PASTED")
         app_state.state = State.PLAN_PASTED
         app_state.parse_error_time = None
 
-    # Handle PARSE_ERROR state - allow user to retry immediately
+    # Handle PARSE_ERROR state — allow user to retry immediately
     if app_state.state == State.PARSE_ERROR:
-        print("Parse error state - resetting to copy new consultation")
+        logger.info("In PARSE_ERROR — resetting to retry consultation copy")
         app_state.state = State.PLAN_PASTED
         app_state.parse_error_time = None
         handle_plan_pasted_state(app_state)
+        return  # ← prevent fall-through to dispatcher
 
     # State machine dispatcher
-    # If plan paste window has expired, just reset state (don't handle it)
     if (
         app_state.state == State.PLAN_PASTE and app_state.is_plan_paste_expired()
     ):
-        print("Plan paste window expired, resetting to normal state")
+        logger.info("Plan paste window expired — resetting to PLAN_PASTED")
         app_state.state = State.PLAN_PASTED
 
     elif app_state.state == State.PLAN_PASTED:
@@ -289,9 +356,23 @@ def middle_mouse(app_state):
         handle_plan_paste_state(app_state)
 
     else:
-        print("Section 4: ??")
+        logger.warning("Unhandled state: %s — no action taken", app_state.state.name)
 
-    print("Click!")
+    logger.debug("Middle click processing complete — new state: %s", app_state.state.name)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _safe_preview(text: str, max_chars: int = 500) -> str:
+    """Return a truncated, newline-safe preview of text for logging."""
+    if not text:
+        return "<empty>"
+    preview = text[:max_chars]
+    if len(text) > max_chars:
+        preview += f" … [truncated, total {len(text)} chars]"
+    return preview.replace("\r\n", "\\r\\n").replace("\n", "\\n")
 
 
 def create_image(width, height, color1, color2):
@@ -300,56 +381,77 @@ def create_image(width, height, color1, color2):
     dc = ImageDraw.Draw(image)
     dc.rectangle((width // 2, 0, width, height // 2), fill=color2)
     dc.rectangle((0, height // 2, width // 2, height), fill=color2)
-
     return image
 
-def toggle_consent(app_state, icon, item):
-    """Toggle the consent recording flag.
 
-    Args:
-        app_state: ApplicationState instance
-        icon: System tray icon instance
-        item: Menu item that was clicked
-    """
+# ---------------------------------------------------------------------------
+# Menu callbacks
+# ---------------------------------------------------------------------------
+
+def toggle_consent(app_state, icon, item):
     app_state.record_consent = not item.checked
+    logger.info("Record consent toggled → %s", app_state.record_consent)
 
 
 def toggle_bypass_gui(app_state, icon, item):
-    """Toggle the GUI bypass flag.
-
-    Args:
-        app_state: ApplicationState instance
-        icon: System tray icon instance
-        item: Menu item that was clicked
-    """
     app_state.bypass_gui = not item.checked
+    logger.info("Bypass GUI toggled → %s", app_state.bypass_gui)
 
+
+def toggle_debug(app_state, icon, item):
+    """Toggle debug (verbose) console logging."""
+    new_val = not item.checked
+    set_console_debug(new_val)
+    logger.info("Debug mode toggled → %s (log file always captures DEBUG)", new_val)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
 def main():
     """Main entry point for the application."""
-    # Initialize icon manager first
+    setup_logging(debug_mode=False)
+
+    logger.info("=" * 60)
+    logger.info("AI Scribe Reformatter starting")
+    logger.info("Python: %s | Executable: %s", sys.version.replace("\n", " "), sys.executable)
+    logger.info("Working directory: %s", Path.cwd())
+    logger.info("=" * 60)
+
     icon_manager = IconManager()
     app_state = ApplicationState(icon_manager=icon_manager)
 
     # Store icon reference for updates
-    icon_ref = [None]  # Use list to allow assignment in nested function
+    icon_ref = [None]
 
     def quit(icon, item):
+        logger.info("Exit requested — shutting down")
         icon.stop()
         exit(0)
 
-    # Wrapper that updates icon after state changes
+    # Wrapper that updates icon after state changes and catches errors
     def wrapped_middle_mouse():
         old_state = app_state.state
-        middle_mouse(app_state)
+        try:
+            middle_mouse(app_state)
+        except Exception as e:
+            # Catch-all so the mouse callback is NEVER killed by an unhandled exception.
+            # This was the root cause of the "red cross + stops responding" bug.
+            logger.critical("UNHANDLED exception in middle_mouse callback: %s: %s",
+                            type(e).__name__, e, exc_info=True)
+            app_state.state = State.PARSE_ERROR
+            app_state.parse_error_time = datetime.now()
+
         new_state = app_state.state
 
         if icon_ref[0] and app_state.icon_manager and old_state != new_state:
             try:
                 new_icon = app_state.icon_manager.get_icon_for_state(new_state)
                 icon_ref[0].icon = new_icon
+                logger.debug("Tray icon updated: %s → %s", old_state.name, new_state.name)
             except Exception as e:
-                print(f"Error updating icon: {e}")
+                logger.error("Error updating tray icon: %s", e, exc_info=True)
 
     # Register mouse event with wrapped callback
     mouse.on_button(
@@ -357,13 +459,14 @@ def main():
         buttons=(mouse.MIDDLE),
         types=(mouse.DOWN, mouse.DOUBLE)
     )
+    logger.info("Middle mouse button listener registered")
 
-    # Create system tray icon with initial state
+    # Create system tray icon
     icon = pystray.Icon(
         "test name",
         icon=icon_manager.get_icon_for_state(app_state.state),
         menu=pystray.Menu(
-            pystray.MenuItem("Documentation History Importer", None),
+            pystray.MenuItem("AI Scribe Reformatter", None),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem(
                 "Automatically Record Consent",
@@ -375,11 +478,18 @@ def main():
                 lambda icon, item: toggle_bypass_gui(app_state, icon, item),
                 checked=lambda item: app_state.bypass_gui
             ),
+            pystray.MenuItem(
+                "Debug Mode (verbose console)",
+                lambda icon, item: toggle_debug(app_state, icon, item),
+                checked=lambda item: False
+            ),
+            pystray.Menu.SEPARATOR,
             pystray.MenuItem("Exit", quit)
         ),
     )
 
-    icon_ref[0] = icon  # Store reference for icon updates
+    icon_ref[0] = icon
+    logger.info("System tray icon created — running")
     icon.run()
 
 


### PR DESCRIPTION
- Add comprehensive logging with file handler (always DEBUG) and console handler
- Log file written to scribe_reformatter_debug.log in cwd
- Add 'Debug Mode (verbose console)' toggle to tray menu
- Log state transitions, clipboard previews, parsed sections, all errors with tracebacks
- Log startup info (Python version, exe path, working directory)

Bug fixes:
- Wrap ag.click()/ag.hotkey() in try/except to prevent unhandled exceptions killing the mouse callback permanently (root cause of red cross + no response)
- Add catch-all in wrapped_middle_mouse() as safety net
- Add return after PARSE_ERROR retry to prevent fall-through to dispatcher
- Fix Patient Summary stripping to handle both \r\n and \n line endings
- Add logging to clipboard_parser.py for block parsing and section routing